### PR TITLE
Fix font scaling on rotated outputs

### DIFF
--- a/font
+++ b/font
@@ -194,8 +194,9 @@ sub get_dpi_at
   foreach (grep {m/ connected /} `xrandr 2> /dev/null`) {
     # Parse monitor dimensions from xrandr output, and skip if the given point
     # is not on this monitor
-    my ($w, $h, $x, $y, $wmm, $hmm) = m/\b(\d+)x(\d+)([-+]\d+)([-+]\d+) .* (\d+)mm x (\d+)mm\b/;
+    my ($w, $h, $x, $y, $rot, $wmm, $hmm) = m/\b(\d+)x(\d+)([-+]\d+)([-+]\d+) (\w*).* (\d+)mm x (\d+)mm\b/;
     next if $px < $x or $py < $y or $px >= $x + $w or $py >= $y + $h;
+    ($wmm, $hmm) = ($hmm, $wmm) if $rot eq "left" or $rot eq "right";
 
     # Calculate DPI based on width alone for now:
     #   screen width in pixels / screen width in inches


### PR DESCRIPTION
When an output is rotated with xrandr, the command-line utility prints the pixel dimensions of the display as rotated, but the physical dimensions of the display without rotation.  As a result, when the rotation is "left" or "right", they didn't match each other, and the wrong font scale was calculated.  Check explicitly for this.